### PR TITLE
Enable editing and meal type change for items on Heute page

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,6 +389,15 @@
             </div>
             <div class="space-y-3">
                 <div>
+                    <label for="modalMealTypeSelect" class="block text-sm font-medium text-gray-700 mb-1">Mahlzeit</label>
+                    <select id="modalMealTypeSelect" class="w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                        <option value="Frühstück">Frühstück</option>
+                        <option value="Mittagessen">Mittagessen</option>
+                        <option value="Abendessen">Abendessen</option>
+                        <option value="Snacks">Snacks</option>
+                    </select>
+                </div>
+                <div>
                     <label for="modalKcalInput" class="flex items-center text-sm font-medium text-gray-700 mb-1">
                         <span class="w-3 h-3 rounded-full bg-gray-200 mr-2"></span>Kalorien (kcal)
                     </label>
@@ -490,8 +499,8 @@
                     <!-- Product items will be dynamically inserted here -->
                 </div>
                 <div>
-                    <label for="modalProductPortionInput" class="block text-sm font-medium text-gray-700 mb-1">Portion (g)</label>
-                    <input type="number" id="modalProductPortionInput" class="w-full p-2 border border-gray-300 rounded-md" placeholder="z.B. 150">
+                    <label for="modalAddMeal_PortionInput" class="block text-sm font-medium text-gray-700 mb-1">Portion (g)</label>
+                    <input type="number" id="modalAddMeal_PortionInput" class="w-full p-2 border border-gray-300 rounded-md" placeholder="z.B. 150">
                 </div>
             </div>
             <div class="flex justify-end space-x-4 mt-6">


### PR DESCRIPTION
Implements functionality to allow you to click on food items listed on the 'Heute' (Today) page under Breakfast, Lunch, Dinner, and Snacks. Clicking an item opens a modal ('foodDetailModal') where you can:
- Modify nutritional information (kcal, carbs, protein, fat)
- Change the portion size
- Change the meal type (Frühstück, Mittagessen, Abendessen, Snacks)
- Delete the food entry

The changes are reflected on both the 'Heute' page and the 'Übersicht' (Overview) page.

fix: Correct portion handling in 'Add Product to Meal' modal

Addresses issues in the 'Add Product to Meal' modal:
- The portion input field now correctly defaults to the selected product's predefined portion size, if available, or is cleared to encourage your input (instead of a fixed 150g).
- Ensures that the portion size manually entered by you in this modal is respected when the product is added to a meal, overriding the product's default portion if different.
- Resolved an HTML ID collision for the portion input field in the 'Add Product to Meal' modal to ensure correct behavior.